### PR TITLE
Added user_complex search method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
+cover/
 .tox/
 .coverage
 .cache
@@ -53,6 +54,9 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# PyCharm
+.idea/
 
 _build
 Chino_API_Python_.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
+local_env.bat
 htmlcov/
 cover/
 .tox/

--- a/chino/api.py
+++ b/chino/api.py
@@ -682,6 +682,22 @@ class ChinoAPISearches(ChinoAPIBase):
         else:
             return ListResult(User, self.apicall('POST', url, data=data, params=kwargs))
 
+    def users_complex(self, user_schema_id, query, result_type="FULL_CONTENT", sort=None,
+                  **kwargs):
+        url = 'search/users/%s' % user_schema_id
+        if not sort:
+            sort = []
+        data = dict(result_type=result_type,
+                    query=query)
+        if sort:
+            data['sort'] = sort
+        if result_type == "COUNT":
+            return self.apicall('POST', url, data=data, params=kwargs)['count']
+        elif result_type == "ONLY_ID":
+            return ListResult(IDs, self.apicall('POST', url, data=data, params=kwargs))
+        else:
+            return ListResult(User, self.apicall('POST', url, data=data, params=kwargs))
+
 
 class ChinoAuth(object):
     customer_id = None

--- a/chino/api.py
+++ b/chino/api.py
@@ -644,6 +644,8 @@ class ChinoAPISearches(ChinoAPIBase):
             data['sort'] = sort
         if result_type == "COUNT":
             return self.apicall('POST', url, data=data, params=kwargs)['count']
+        elif result_type == "EXISTS":
+            return bool(self.apicall('POST', url, data=data, params=kwargs)['exists'])
         elif result_type == "ONLY_ID":
             return ListResult(IDs, self.apicall('POST', url, data=data, params=kwargs))
         else:
@@ -660,6 +662,8 @@ class ChinoAPISearches(ChinoAPIBase):
             data['sort'] = sort
         if result_type == "COUNT":
             return self.apicall('POST', url, data=data, params=kwargs)['count']
+        elif result_type == "EXISTS":
+            return bool(self.apicall('POST', url, data=data, params=kwargs)['exists'])
         elif result_type == "ONLY_ID":
             return ListResult(IDs, self.apicall('POST', url, data=data, params=kwargs))
         else:
@@ -693,8 +697,8 @@ class ChinoAPISearches(ChinoAPIBase):
             data['sort'] = sort
         if result_type == "COUNT":
             return self.apicall('POST', url, data=data, params=kwargs)['count']
-        elif result_type == "ONLY_ID":
-            return ListResult(IDs, self.apicall('POST', url, data=data, params=kwargs))
+        elif result_type == "EXISTS" or result_type == "USERNAME_EXISTS":
+            return self.apicall('POST', url, data=data, params=kwargs)['exists']
         else:
             return ListResult(User, self.apicall('POST', url, data=data, params=kwargs))
 

--- a/chino/objects.py
+++ b/chino/objects.py
@@ -101,8 +101,8 @@ class _DictContent(ChinoBaseObject):
 
 
 class IDs(ChinoBaseObject):
-    __str_name__ = 'id'
-    __str_names__ = 'ids'
+    __str_name__ = 'ID'
+    __str_names__ = 'IDs'
 
     def __init__(self, id):
         self.id = id

--- a/test/tests_chino.py
+++ b/test/tests_chino.py
@@ -821,6 +821,8 @@ class SearchUsersChinoTest(BaseChinoTest):
                                     attributes=dict(fieldInt=123, fieldString='test', fieldBool=False,
                                                     fieldDate='2015-02-19',
                                                     fieldDateTime='2015-02-19T16:39:47'))
+            time.sleep(3)
+
         last_doc = self.chino.users.create(self.schema, username="user_test_last", password='1234567890AAaa',
                                            attributes=dict(fieldInt=123, fieldString='test', fieldBool=False,
                                                            fieldDate='2015-02-19',

--- a/test/tests_chino.py
+++ b/test/tests_chino.py
@@ -815,7 +815,7 @@ class SearchUsersChinoTest(BaseChinoTest):
             self.chino.users.delete(user._id, force=True)
         self.chino.user_schemas.delete(self.schema, True)
 
-    def test_search_docs(self):
+    def test_search_users(self):
         for i in range(9):
             self.chino.users.create(self.schema, username="user_test_%s" % i, password='1234567890AAaa',
                                     attributes=dict(fieldInt=123, fieldString='test', fieldBool=False,
@@ -827,7 +827,7 @@ class SearchUsersChinoTest(BaseChinoTest):
                                                            fieldDateTime='2015-02-19T16:39:47'))
 
         # self.chino.searches.search(self.schema) # TODO: improve tests
-        time.sleep(5)  # wait the index max update time
+        time.sleep(10)  # wait twice the index max update time
         res = self.chino.searches.users(self.schema, filters=[{"field": "fieldInt", "type": "eq", "value": 123}])
         self.assertEqual(res.paging.total_count, 10, res)
         res = self.chino.searches.users(self.schema,
@@ -839,7 +839,10 @@ class SearchUsersChinoTest(BaseChinoTest):
         res = self.chino.searches.users(self.schema, filters=[{"field": "fieldInt", "type": "eq", "value": 123}])
         self.assertEqual(res.paging.total_count, 9, res)
 
-    def test_search_docs_consistent(self):
+        res = self.chino.searches.users_complex(self.schema, query={"field": "fieldInt", "type": "eq", "value": 123})
+        self.assertEqual(res.paging.total_count, 9, res)
+
+    def test_search_users_consistent(self):
         doc = None
         for i in range(4):
             doc = self.chino.users.create(self.schema, username="user_test_%s" % i, password='1234567890AAaa',


### PR DESCRIPTION
Now it is possible to use the new Search API also with users.

```python
query_dict = {"field": "field_name", "type": "eq", "value": "field_value"}
chino.searches.users_complex(schema_id, query=query_dict)
```

Test results:

    ..S...............S..............
    Name                  Stmts   Miss  Cover
    -----------------------------------------
    chino\__init__.py         1      0   100%
    chino\api.py            541     54    90%
    chino\exceptions.py      24      4    83%
    chino\objects.py        309     68    78%
    -----------------------------------------
    TOTAL                   875    126    86%
    ----------------------------------------------------------------------
    Ran 33 tests in 311.789s
    
    OK (SKIP=2)
